### PR TITLE
Fix CI limit argument in iv_adjusted_limit functions

### DIFF
--- a/R/bounds.R
+++ b/R/bounds.R
@@ -114,7 +114,7 @@ iv_adjusted_limit.lm <- function(fs,
   call.args   <- list(r2zw.x,
                       r2y0w.zx,
                       alpha = alpha,
-                      ci.limi = ci.limit,
+                      ci.limit = ci.limit,
                       ...)
   iv.data     <- iv_model_helper(fs = fs, rf = rf, instrument = instrument)
   args        <- c(iv.data, call.args)

--- a/R/plots.R
+++ b/R/plots.R
@@ -550,7 +550,7 @@ iv_adjusted_limit.lm <- function(fs,
   call.args   <- list(r2zw.x,
                       r2y0w.zx,
                       alpha = alpha,
-                      ci.limi = ci.limit,
+                      ci.limit = ci.limit,
                       max = max,
                       ...)
   iv.data     <- iv_model_helper(fs = fs, rf = rf, instrument = instrument)


### PR DESCRIPTION
## Summary
- ensure iv_adjusted_limit correctly passes `ci.limit` in bounds and plot helpers

## Testing
- `R CMD build .` *(fails: command not found)*