### PR TITLE
Fix small documentation typo

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -106,7 +106,7 @@ plot.iv.sensemakr = function(x,
 ##' Contour plots of omitted variable bias for IV
 ##'
 ##' @description
-##' Contour plots of omitted variable bias for sensitivity analysis of instrumental variable estimtes.
+##' Contour plots of omitted variable bias for sensitivity analysis of instrumental variable estimates.
 ##'
 ##' The main inputs are an \code{\link{iv_fit}} model, and the covariates used for benchmarking the strength of omitted variables.
 ##'

--- a/man/ovb_contour_plot.Rd
+++ b/man/ovb_contour_plot.Rd
@@ -53,7 +53,7 @@ W with the instrument Z, given observed covariates X.}
 \item{ylab}{label of y axis. If `NULL`, default label is used.}
 }
 \description{
-Contour plots of omitted variable bias for sensitivity analysis of instrumental variable estimtes.
+Contour plots of omitted variable bias for sensitivity analysis of instrumental variable estimates.
 
 The main inputs are an \code{\link{iv_fit}} model, and the covariates used for benchmarking the strength of omitted variables.
 


### PR DESCRIPTION
## Summary
- correct misspelled "estimtes" to "estimates" in `R/plots.R`
- fix the same typo in generated documentation `man/ovb_contour_plot.Rd`

## Testing
- `R` not available, so no tests run