### PR TITLE
Fix label for reduced-form bounds

### DIFF
--- a/R/sensemakr.R
+++ b/R/sensemakr.R
@@ -341,7 +341,7 @@ print.summary.iv.sensemakr <- function(x, digits = 3, ...){
   if(!is.null(x$bounds$rf)){
     cat("Bounds on Omitted Variable Bias:")
     cat("\n")
-    print(setNames(x$bounds$rf, c("Bound Label", "R2zw.x", "R2dw.zx", "Lower CI", "Upper CI", "Crit. Thr.")), digits = digits,row.names = F)
+    print(setNames(x$bounds$rf, c("Bound Label", "R2zw.x", "R2yw.zx", "Lower CI", "Upper CI", "Crit. Thr.")), digits = digits,row.names = F)
     cat("\n")
   }
   cat("Note:",


### PR DESCRIPTION
## Summary
- correct label for the reduced-form bounds table in `print.summary.iv.sensemakr`

## Testing
- `R -q -e 'devtools::test()'` *(fails: `bash: R: command not found`)*